### PR TITLE
[codex] Fix ratio check cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  go:
+    name: Go
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...

--- a/pkg/ratio/check.go
+++ b/pkg/ratio/check.go
@@ -7,10 +7,10 @@ import (
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
-	"log"
-	"os/exec"
 	"time"
 )
+
+const checkTimeout = 30 * time.Second
 
 type Result struct {
 	ContentArea float64 `json:"content_area"`
@@ -19,16 +19,11 @@ type Result struct {
 }
 
 func Get(parentCtx context.Context, url string) (*Result, error) {
-	ctx, cancel := chromedp.NewContext(parentCtx)
-	defer func() {
-		cancel()
-		// Prevent Chromium processes from hanging
-		if _, err := exec.Command("pkill", "-g", "0", "Chromium").Output(); err != nil {
-			log.Println("[warn] Failed to kill Chromium processes", err)
-		}
-	}()
+	timeoutCtx, cancelTimeout := context.WithTimeout(parentCtx, checkTimeout)
+	defer cancelTimeout()
 
-	chromedp.WithPollingTimeout(5 * time.Second)
+	ctx, cancel := chromedp.NewContext(timeoutCtx)
+	defer cancel()
 
 	ratio := &Result{}
 


### PR DESCRIPTION
## Summary

- replace the no-op polling timeout call with a real 30 second context deadline
- remove the process-group pkill that could terminate unrelated or concurrent Chromium work
- rely on chromedp context cancellation for browser cleanup

## Why

Each ratio check previously ran pkill -g 0 Chromium when it returned, which can kill other in-flight checks in server mode. The timeout call was also discarded, so slow page loads had no effective deadline.

## Validation

- go test ./...