### PR TITLE
[codex] Add Go CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  go:
+    name: Go
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow for Go pull requests and main branch pushes
- check gofmt output, run go vet, and run go test ./...
- use the Go version declared in go.mod with setup-go caching enabled

## Why

The build/import mismatch was not caught before landing. A small CI workflow gives every PR a basic compile, test, vet, and formatting gate.

## Validation

- go test ./...